### PR TITLE
layout.conf: s/haskell/haskell-unofficial/

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,1 +1,1 @@
-masters = arbor x11 gnome haskell
+masters = arbor x11 gnome haskell-unofficial


### PR DESCRIPTION
haskell is now deprecated in favour of haskell-unofficial
https://lists.exherbo.org/pipermail/exherbo-dev/2018-September/001563.html